### PR TITLE
Fix rare panic from FixedOffset::east out of bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-fuzz"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-fuzz"
 description = "Generates example data from JSON Typedef schemas"
-version = "0.1.11"
+version = "0.1.12"
 license = "MIT"
 authors = ["JSON Typedef Contributors"]
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,9 @@ const MAX_SEQ_LENGTH: u8 = 8;
 /// let mut rng = rand_pcg::Pcg32::seed_from_u64(8927);
 ///
 /// assert_eq!(jtd_fuzz::fuzz(&schema, &mut rng), json!({
-///     "name": "=T$m;[5",
-///     "createdAt": "2012-03-15T02:51:27+10:31",
-///     "favoriteNumbers": [142, 236, 67]
+///     "name": "e",
+///     "createdAt": "1931-10-18T14:26:10-05:14",
+///     "favoriteNumbers": [166, 142]
 /// }));
 /// ```
 pub fn fuzz<R: rand::Rng>(schema: &jtd::Schema, rng: &mut R) -> Value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ fn fuzz_with_root<R: rand::Rng>(root: &jtd::Schema, rng: &mut R, schema: &jtd::S
                     // Although timestamp_millis accepts an i64, not all values
                     // in that range are permissible. The i32 range is entirely
                     // safe.
-                    chrono::FixedOffset::east(rng.gen_range(-86_400, 86_400))
+                    chrono::FixedOffset::east(rng.gen_range(-86_400 + 1, 86_400 - 1))
                         .timestamp(rng.gen::<i32>() as i64, 0)
                         .to_rfc3339()
                         .into()


### PR DESCRIPTION
There is an approximately a 1-in-86400 chance that fuzzing against `{ "type": "timestamp" }` will panic. This PR fixes that, so that the code doesn't panic.

The root cause is that `chrono::FixedOffset::east` accepts data in `(-86400,86400)` (i.e., an exclusive range), but the previous `gen_range` was generating data in `[-86400,86400]` (i.e., an inclusive range). That leaves an approximately 1-in-86400 chance of generating something at this boundary condition, causing a panic.

The fix is just to offset the `gen_range` lower bound up by 1, and the upper bound down by 1.

Previously:

```
$ echo '{ "type": "timestamp" }' | cargo run -- -n 1000000 > /dev/null
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/jtd-fuzz -n 1000000`
thread 'main' panicked at 'FixedOffset::east out of bounds', /Users/ulysse.carion/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.11/src/offset/fixed.rs:43:37
```

After this PR:

```
$ echo '{ "type": "timestamp" }' | cargo run -- -n 1000000 > /dev/null
    Finished dev [unoptimized + debuginfo] target(s) in 1.67s
     Running `target/debug/jtd-fuzz -n 1000000`
```