### PR TITLE
Bump to jtd v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "jtd"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da2c72fdc110e4efa643b01d7c181a5ff3f7e45e4d112d0e3b732bdd57026ce"
+checksum = "54f0964332e071f2832a3ecd241ec19dcc5ae55992bc573c04b40e69ab95bc52"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-fuzz"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-fuzz"
 description = "Generates example data from JSON Typedef schemas"
-version = "0.1.12"
+version = "0.1.13"
 license = "MIT"
 authors = ["JSON Typedef Contributors"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["JSON Typedef Contributors"]
 edition = "2018"
 
 [dependencies]
-jtd = "^0.1.4"
+jtd = "^0.2"
 serde_json = "^1"
 rand = "^0.7"
 chrono = "^0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 use rand::seq::IteratorRandom;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // Max length when generating "sequences" of things, such as strings, arrays,
 // and objects.
@@ -100,8 +100,8 @@ fn fuzz_with_root<R: rand::Rng>(root: &jtd::Schema, rng: &mut R, schema: &jtd::S
                 // why it's important these come after the "primitive" cases.
                 5 => {
                     let schema = jtd::Schema {
-                        metadata: HashMap::new(),
-                        definitions: HashMap::new(),
+                        metadata: BTreeMap::new(),
+                        definitions: BTreeMap::new(),
                         form: jtd::Form::Elements(jtd::form::Elements {
                             nullable: false,
                             schema: Default::default(),
@@ -113,8 +113,8 @@ fn fuzz_with_root<R: rand::Rng>(root: &jtd::Schema, rng: &mut R, schema: &jtd::S
 
                 6 => {
                     let schema = jtd::Schema {
-                        metadata: HashMap::new(),
-                        definitions: HashMap::new(),
+                        metadata: BTreeMap::new(),
+                        definitions: BTreeMap::new(),
                         form: jtd::Form::Values(jtd::form::Values {
                             nullable: false,
                             schema: Default::default(),
@@ -216,7 +216,7 @@ fn fuzz_with_root<R: rand::Rng>(root: &jtd::Schema, rng: &mut R, schema: &jtd::S
                 return Value::Null;
             }
 
-            let mut members = HashMap::new();
+            let mut members = BTreeMap::new();
 
             let mut required_keys: Vec<_> = required.keys().cloned().collect();
             required_keys.sort();


### PR DESCRIPTION
This PR bumps jtd-fuzz's dependency on `jtd` to version `0.2.1`.

Doing so incorporates a fix in: https://github.com/jsontypedef/json-typedef-rust/pull/13