### PR TITLE
Limit timestamp offsets from -18:00 to +18:00

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-fuzz"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-fuzz"
 description = "Generates example data from JSON Typedef schemas"
-version = "0.1.13"
+version = "0.1.14"
 license = "MIT"
 authors = ["JSON Typedef Contributors"]
 edition = "2018"


### PR DESCRIPTION
As described in the new comment in this PR, Java's standard library only supports offsets of up to 18 hours from UTC.

This PR adopts that restriction as well, so that the fuzzed timestamps are more useful out-of-the-box.