### PR TITLE
Make fuzzed additional properties "case-insensitive"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-fuzz"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-fuzz"
 description = "Generates example data from JSON Typedef schemas"
-version = "0.1.14"
+version = "0.1.15"
 license = "MIT"
 authors = ["JSON Typedef Contributors"]
 edition = "2018"


### PR DESCRIPTION
This PR makes `jtd-fuzz` more compatible with Go's `encoding/json` package, which is case-insensitive for the purposes of JSON serialization/deserialization from/to structs.

As an example of what I mean, for this schema:

```
{
    "properties": {
        "a": {
            "type": "boolean"
        },
        "b": {
            "type": "string"
        },
        "c": {
            "elements": {
                "type": "string"
            }
        },
        "d": {
            "values": {
                "type": "string"
            }
        }
    },
    "optionalProperties": {
        "e": {
            "type": "boolean"
        },
        "f": {
            "type": "string"
        },
        "g": {
            "elements": {
                "type": "string"
            }
        },
        "h": {
            "values": {
                "type": "string"
            }
        }
    },
    "additionalProperties": true
}
```

We may today generate:

```
cargo run -- --seed=0 --num-values=100 x.json | sed -n 44p
```

```json
{"":">;*yPM","5N3[B":false,"D":"-rT","GP~n":null,"S=B":false,"a":false,"b":"vl+M","c":["6mP\\=","g","I6-5\"%","n%x8Z","`\\zo\\LX","R7q\"?t"],"d":{},"e":false,"g":["14n~Q^","","n,.1_",""],"h":{"!KP":"]b;{^!","(o~SOP":"k@Z",".!":"0VxNo|"},"sU6NaP@":0.22554846356159974,"u":null}
```

Which contains `"D":"-rT"`. This doesn't work well with Go in practice. With this PR, we will not generate this sort of data any more.