### PR TITLE
Rename crate back to jtd-fuzz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "jtd_fuzz"
+name = "jtd-fuzz"
 version = "0.1.18"
 dependencies = [
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-fuzz"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jtd_fuzz"
+name = "jtd-fuzz"
 description = "Generates example data from JSON Typedef schemas"
 version = "0.1.18"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-fuzz"
 description = "Generates example data from JSON Typedef schemas"
-version = "0.1.18"
+version = "0.1.19"
 license = "MIT"
 authors = ["JSON Typedef Contributors"]
 edition = "2018"


### PR DESCRIPTION
This will hopefully fix errors from crates.io related to an existing name. I cannot for the life of me find any documentation as to what is going on here.