### PR TITLE
Release v0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-fuzz"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-fuzz"
 description = "Generates example data from JSON Typedef schemas"
-version = "0.1.20"
+version = "0.1.21"
 license = "MIT"
 authors = ["JSON Typedef Contributors"]
 edition = "2018"


### PR DESCRIPTION
The release of v0.1.20 did not work because I tagged the wrong SHA. This PR is for skipping over to releasing 0.1.21 instead.